### PR TITLE
added point type parameter for issue #13

### DIFF
--- a/DbscanDemo/Program.cs
+++ b/DbscanDemo/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using DbscanImplementation;
 
 namespace DbscanDemo
@@ -10,13 +11,13 @@ namespace DbscanDemo
         {
             MyCustomFeature[] featureData = { };
 
-            var testPoints = new List<MyCustomFeature>();
+            var testPoints = new List<MyCustomFeature>() { };
 
             //points around (1,1) with most 1 distance
             testPoints.Add(new MyCustomFeature(1, 1));
             for (int i = 1; i <= 1000; i++)
             {
-                float v = ((float)i / 1000);
+                var v = (float)i / 1000;
                 testPoints.Add(new MyCustomFeature(1, 1 + v));
                 testPoints.Add(new MyCustomFeature(1, 1 - v));
                 testPoints.Add(new MyCustomFeature(1 - v, 1));
@@ -27,12 +28,15 @@ namespace DbscanDemo
             testPoints.Add(new MyCustomFeature(5, 5));
             for (int i = 1; i <= 1000; i++)
             {
-                float v = ((float)i / 1000);
+                var v = (float)i / 1000;
                 testPoints.Add(new MyCustomFeature(5, 5 + v));
                 testPoints.Add(new MyCustomFeature(5, 5 - v));
                 testPoints.Add(new MyCustomFeature(5 - v, 5));
                 testPoints.Add(new MyCustomFeature(5 + v, 5));
             }
+
+            //noise point
+            testPoints.Add(new MyCustomFeature(10, 10));
 
             featureData = testPoints.ToArray();
 
@@ -46,6 +50,18 @@ namespace DbscanDemo
                 );
 
             var result = dbscan.ComputeClusterDbscan(allPoints: featureData, epsilon: .01, minimumPoints: 10);
+
+            Console.WriteLine($"Unclassified: {result.Unclassified.Length}");
+
+            Console.WriteLine($"Noise: {result.Noise.Length}");
+
+            Console.WriteLine($"# of Clusters: {result.Clusters.Count}");
+
+            Console.WriteLine("Unclassified points in Clusters: " +
+                $"{result.Clusters.SelectMany(x => x.Value).Where(x => x.PointType == PointType.Unclassified).Count()}");
+
+            Console.WriteLine("Not Visited points in Clusters: " +
+                $"{result.Clusters.SelectMany(x => x.Value).Where(x => !x.IsVisited).Count()}");
         }
     }
 }

--- a/DbscanImplementation/ClusterId.cs
+++ b/DbscanImplementation/ClusterId.cs
@@ -1,0 +1,15 @@
+namespace DbscanImplementation
+{
+    public enum ClusterId
+    {
+        /// <summary>
+        /// This Id shows when a point is IsVisited value equals to false.
+        /// </summary>
+        Unclassified = -1,
+
+        /// <summary>
+        /// This Id shows when a point is not a member of a cluster.
+        /// </summary>
+        Noise = 0
+    }
+}

--- a/DbscanImplementation/ClusterIds.cs
+++ b/DbscanImplementation/ClusterIds.cs
@@ -1,8 +1,0 @@
-namespace DbscanImplementation
-{
-    public enum ClusterIds
-    {
-        Unclassified = 0,
-        Noise = -1
-    }
-}

--- a/DbscanImplementation/DbscanAlgorithm.cs
+++ b/DbscanImplementation/DbscanAlgorithm.cs
@@ -59,7 +59,9 @@ namespace DbscanImplementation
 
                 if (neighborPoints.Length < minimumPoints)
                 {
-                    lookupPoint.ClusterId = (int)ClusterIds.Noise;
+                    lookupPoint.ClusterId = (int)ClusterId.Noise;
+
+                    lookupPoint.PointType = PointType.Noise;
                 }
                 else
                 {
@@ -67,7 +69,9 @@ namespace DbscanImplementation
 
                     lookupPoint.ClusterId = clusterId;
 
-                    neighborPoints = ExpandCluster(allPointsDbscan, neighborPoints, clusterId, epsilon, minimumPoints);
+                    lookupPoint.PointType = PointType.Core;
+
+                    ExpandCluster(allPointsDbscan, neighborPoints, clusterId, epsilon, minimumPoints);
                 }
             }
 
@@ -82,8 +86,7 @@ namespace DbscanImplementation
         /// <param name="clusterId">given clusterId</param>
         /// <param name="epsilon">Desired region ball radius</param>
         /// <param name="minimumPoints">Minimum number of points to be in a region</param>
-        /// <returns>expanded neighbor points</returns>
-        private DbscanPoint<TFeature>[] ExpandCluster(
+        private void ExpandCluster(
             DbscanPoint<TFeature>[] allPoints, DbscanPoint<TFeature>[] neighborPoints,
             int clusterId, double epsilon, int minimumPoints)
         {
@@ -99,17 +102,21 @@ namespace DbscanImplementation
 
                     if (otherNeighborPoints.Length >= minimumPoints)
                     {
+                        neighborPoint.PointType = PointType.Core;
+
                         neighborPoints = neighborPoints.Union(otherNeighborPoints).ToArray();
+                    }
+                    else
+                    {
+                        neighborPoint.PointType = PointType.Border;
                     }
                 }
 
-                if (neighborPoint.ClusterId == (int)ClusterIds.Unclassified)
+                if (neighborPoint.ClusterId == (int)ClusterId.Unclassified)
                 {
                     neighborPoint.ClusterId = clusterId;
                 }
             }
-
-            return neighborPoints;
         }
 
         /// <summary>

--- a/DbscanImplementation/DbscanPoint.cs
+++ b/DbscanImplementation/DbscanPoint.cs
@@ -6,17 +6,20 @@ namespace DbscanImplementation
     /// <typeparam name="TFeature">Feature data contribute into algorithm</typeparam>
     public class DbscanPoint<TFeature>
     {
-        public bool IsVisited { get; internal set; }
-
         public TFeature Feature { get; internal set; }
 
+        public bool IsVisited { get; internal set; }
+
         public int ClusterId { get; internal set; }
+
+        public PointType PointType { get; internal set; }
 
         public DbscanPoint(TFeature feature)
         {
             Feature = feature;
             IsVisited = false;
-            ClusterId = (int)ClusterIds.Unclassified;
+            ClusterId = (int)DbscanImplementation.ClusterId.Unclassified;
+            PointType = PointType.Unclassified;
         }
     }
 }

--- a/DbscanImplementation/DbscanResult.cs
+++ b/DbscanImplementation/DbscanResult.cs
@@ -16,8 +16,8 @@ namespace DbscanImplementation
                 .ToDictionary(x => x.Key, x => x.ToArray());
 
             Clusters = new Dictionary<int, DbscanPoint<TFeature>[]>(allClusters.Where(x => x.Key > 0));
-            Noise = allClusters.ContainsKey((int)ClusterIds.Noise) ? allClusters[(int)ClusterIds.Noise] : new DbscanPoint<TFeature>[0];
-            Unclassified = allClusters.ContainsKey((int)ClusterIds.Unclassified) ? allClusters[(int)ClusterIds.Unclassified] : new DbscanPoint<TFeature>[0];
+            Noise = allClusters.ContainsKey((int)ClusterId.Noise) ? allClusters[(int)ClusterId.Noise] : new DbscanPoint<TFeature>[0];
+            Unclassified = allClusters.ContainsKey((int)ClusterId.Unclassified) ? allClusters[(int)ClusterId.Unclassified] : new DbscanPoint<TFeature>[0];
         }
 
         public Dictionary<int, DbscanPoint<TFeature>[]> Clusters { get; }

--- a/DbscanImplementation/PointType.cs
+++ b/DbscanImplementation/PointType.cs
@@ -1,0 +1,14 @@
+namespace DbscanImplementation
+{
+    public enum PointType
+    {        
+        /// <summary>
+        /// This Id shows when a point is IsVisited value equals to false.
+        /// </summary>
+        Unclassified = -1,
+
+        Noise = 0,
+        Core = 1,
+        Border = 2
+    }
+}


### PR DESCRIPTION
Added point type info to each dbscan object: Core, Border, Noise
ClusterIds enum renamed to ClusterId and parameter values reassigned accordingly.
ExpandCluster method unnecessary return value removed. 

Closes #13 